### PR TITLE
Fix: duplicated key number inputs.

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -3,3 +3,12 @@
 
 class WorksheetError(Exception):
     """Base class for exceptions in this module."""
+
+
+class NoIndexRecordedYet(WorksheetError):
+    """Exception raised when no index is recorded yet."""
+
+    def __init__(self):
+        """Initialize the class."""
+        self.message = "No index recorded yet."
+        super().__init__(self.message)

--- a/src/pages/02_🖋 Index.py
+++ b/src/pages/02_🖋 Index.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import streamlit as st
 
+from src.exceptions import NoIndexRecordedYet
 from src.streamlit_page import Page
 
 st.set_page_config(
@@ -36,9 +37,16 @@ class Index(Page):
         """Initialize the class."""
         super(Index, self).__init__()
         self.connect_to_gsheet()
-        self.last_index = self.sheet.get_last_row()["date"]
+
         self.current_month = datetime.now().month
         self.current_year = datetime.now().year
+
+    def fetch_last_index(self):
+        """Fetch the last index recorded."""
+        try:
+            return self.sheet.get_last_row()
+        except IndexError as exc:
+            raise NoIndexRecordedYet from exc
 
     def show_index(self):
         """Show the index page."""
@@ -50,53 +58,87 @@ class Index(Page):
 
     def visualise_index(self):
         """Visualise the index table."""
-        self.check_empty_db()
+        self.check_empty_db(stop=False)
         st.table(self.db)
 
-    def query_infos(self) -> dict:
+    def show_inputs_index_widgets(  # pylint: disable=too-many-arguments
+        self,
+        elecday_min: float = 0.0,
+        elecnight_min: float = 0.0,
+        gas_min: float = 0.0,
+        water_min: float = 0.0,
+        rainwater_min: float = 0.0,
+        tab: str = "fill_index",
+    ) -> dict:
         """Allow the user to fill the index."""
         return {
             "ELECDAY": st.number_input(
-                label=self.map_cols["elecday"], key="number_input_elecday"
+                label=self.map_cols["elecday"],
+                key=f"{tab}_elecday",
+                min_value=elecday_min,
             ),
             "ELECNIGHT": st.number_input(
-                label=self.map_cols["elecnight"], key="number_input_elecnight"
+                label=self.map_cols["elecnight"],
+                key=f"{tab}_elecnight",
+                min_value=elecnight_min,
             ),
             "GAS": st.number_input(
-                label=self.map_cols["gas"],
-                key="number_input_gas",
+                label=self.map_cols["gas"], key=f"{tab}_gas", min_value=gas_min
             ),
             "WATER": st.number_input(
                 label=self.map_cols["water"],
-                key="number_input_water",
+                key=f"{tab}_water",
+                min_value=water_min,
             ),
             "RAINWATER": st.number_input(
                 label=self.map_cols["rainwater"],
-                key="number_input_rainwater",
+                key=f"{tab}_rainwater",
+                min_value=rainwater_min,
             ),
         }
 
     def fill_index(self):
         """Ask the user to fill the index."""
-        if (
-            datetime.strptime(self.last_index, "%Y-%m-%d").month
-            == datetime.now().month
-        ):
-            st.warning(
-                "Vous avez déjà rempli vos index pour ce mois-ci. "
-                "Rendez-vous au début du mois prochain."
-            )
-            # st.stop()
-        else:
-            st.info("Remplissez vos index pour ce mois-ci.")
+        try:
+            last_index = self.fetch_last_index()
+            if (
+                datetime.strptime(last_index["date"], "%Y-%m-%d").month
+                == datetime.now().month
+            ):
+                st.warning(
+                    "Vous avez déjà rempli vos index pour ce mois-ci. "
+                    "Rendez-vous au début du mois prochain."
+                )
+            else:
+                st.info("Remplissez vos index pour ce mois-ci.")
 
+                index_date = datetime(
+                    year=datetime.now().year, month=datetime.now().month, day=1
+                )
+                index_date = datetime.strftime(index_date, "%Y-%m-%d")
+                indexes = list(
+                    self.show_inputs_index_widgets(
+                        elecday_min=last_index["elecday"],
+                        elecnight_min=last_index["elecnight"],
+                        gas_min=last_index["gas"],
+                        water_min=last_index["water"],
+                        rainwater_min=last_index["rainwater"],
+                        tab="fill_index",
+                    ).values()
+                )
+                content = [index_date, *indexes]
+
+                if st.button("Ajouter"):
+                    self.sheet.add_row_to_sheet(list(content))
+                    st.success("Index ajouté !")
+        except NoIndexRecordedYet:
+            st.warning("Aucun index n'a été enregistré pour le moment.")
             index_date = datetime(
                 year=datetime.now().year, month=datetime.now().month, day=1
             )
             index_date = datetime.strftime(index_date, "%Y-%m-%d")
-            indexes = list(self.query_infos().values())
+            indexes = list(self.show_inputs_index_widgets().values())
             content = [index_date, *indexes]
-
             if st.button("Ajouter"):
                 self.sheet.add_row_to_sheet(list(content))
                 st.success("Index ajouté !")
@@ -111,7 +153,11 @@ class Index(Page):
         row_to_correct = self.db[self.db["date"] == selected_date]
         st.table(row_to_correct)
 
-        new_values = list(self.query_infos().values())
+        new_values = list(
+            self.show_inputs_index_widgets(
+                tab="correct_index",
+            ).values()
+        )
         new_content = [selected_date, *new_values]
 
         if st.button("Corriger"):

--- a/src/streamlit_page.py
+++ b/src/streamlit_page.py
@@ -55,14 +55,15 @@ class Page:
             st.error("No sheet found")
             st.stop()
 
-    def check_empty_db(self):
+    def check_empty_db(self, stop: bool = True):
         """Check if the database is empty."""
         if self.db.empty:
             st.markdown(
                 "## 🚨 Aucune donnée n'a été trouvée dans la base de données."
             )
             st.markdown("## 🚨 Veuillez remplir votre base de données.")
-            st.stop()
+            if stop:
+                st.stop()
 
     @staticmethod
     def hide_streamlit_default_layout():


### PR DESCRIPTION
The previous fix did not work properly because the issue still occurs.
This was because the same method which displays different streamlit number inputs widgets was called in two different streamlit tabs within the same page.
This was fixed by adding a parameter to the method to give a different key to the widget.

Example: fill_index_elecday, correct_index_elecday

Additionally, i've added a step to fetch the last recorded values to be used as minimal values for these inputs widgets.



- Added a parameter to give a different key for number inputs widgets depending on the app section.
- Added a min value for the number inputs widgets.
- Set these min values to 0.0 by default.
- If there are records in the database, the min value is the last index.